### PR TITLE
Enable schema validation

### DIFF
--- a/example/pod-procure/validate.py
+++ b/example/pod-procure/validate.py
@@ -23,7 +23,7 @@ def add_arv_hints():
 
     for s in supported_versions:
         print(s)
-        use_custom_schema(s, "https://calrissian-cwl.github.io/schema#", schema_content)
+        use_custom_schema(s, "https://calrissian-cwl.github.io/schema", schema_content)
         print(get_schema(s))
 
     cwltool.process.supportedProcessRequirements.extend([
@@ -49,6 +49,7 @@ stream_err = StringIO()
 res = cwlmain(
     args=parsed_args,
     stdout=stream_out,
+    custom_schema_callback=add_arv_hints
 )
 
 print(stream_out.getvalue())


### PR DESCRIPTION
```
schema_salad.exceptions.SchemaException: Predicate collision on coresMax, 'https://w3id.org/cwl/cwl#ResourceRequirement/coresMax' != 'https://calrissian-cwl.github.io/schema#DaskGatewayRequirement/coresMax'
Enable schema validation
```

So we'll need to either mark this as being the same concept, or you need to rename `coresMax`
